### PR TITLE
Resolvendo bug do split

### DIFF
--- a/src/mappers/MapperObjectChannelAnchor.ts
+++ b/src/mappers/MapperObjectChannelAnchor.ts
@@ -128,9 +128,9 @@ interface IPodcastDTO {
 
 const getMembers =(value:string) => value
 .replace(/(<([^>]+)>)/gi, "")
-.split('Hosts')[1]
+.split('hosts')[1]
 .replace(':', '')
-.replace('Convidados:', '')
+.replace('Guests:', '')
 .replace(/\&nbsp;/g, '')
 .replace(/^\s*\n/gm, '')
 .replace(/,/gm, '')

--- a/src/mappers/MapperObjectChannelAnchor.ts
+++ b/src/mappers/MapperObjectChannelAnchor.ts
@@ -128,7 +128,7 @@ interface IPodcastDTO {
 
 const getMembers =(value:string) => value
 .replace(/(<([^>]+)>)/gi, "")
-.split('hosts')[1]
+.split('HOST')[1]
 .replace(':', '')
 .replace('Guests:', '')
 .replace(/\&nbsp;/g, '')


### PR DESCRIPTION
Resolvendo bug do split, alterando ```Hosts``` -> ```HOST```

Exemplo usado em aula