### PR TITLE
Resolvendo bug do split

### DIFF
--- a/src/mappers/MapperObjectChannelAnchor.ts
+++ b/src/mappers/MapperObjectChannelAnchor.ts
@@ -128,9 +128,9 @@ interface IPodcastDTO {
 
 const getMembers =(value:string) => value
 .replace(/(<([^>]+)>)/gi, "")
-.split('Hosts')[1]
+.split('host')[1]
 .replace(':', '')
-.replace('Convidados:', '')
+.replace('Guets:', '')
 .replace(/\&nbsp;/g, '')
 .replace(/^\s*\n/gm, '')
 .replace(/,/gm, '')


### PR DESCRIPTION
Resolvendo bug do split, alterando ```HOSTS``` -> ```hosts```

-> Exemplo usado em aula